### PR TITLE
Add cpu morpher

### DIFF
--- a/libs/gltfio/CMakeLists.txt
+++ b/libs/gltfio/CMakeLists.txt
@@ -40,6 +40,10 @@ set(SRCS
         src/math.h
         src/upcast.h
         src/Image.cpp
+        src/Morpher.h
+        src/CPUMorpher.h
+        src/CPUMorpher.cpp
+        src/GltfHelpers.h
 )
 
 # ==================================================================================================

--- a/libs/gltfio/include/gltfio/Animator.h
+++ b/libs/gltfio/include/gltfio/Animator.h
@@ -25,6 +25,9 @@ namespace gltfio {
 struct FFilamentAsset;
 struct FFilamentInstance;
 struct AnimatorImpl;
+class Morpher;
+class MorphHelper;
+class CPUMorpher;
 
 /**
  * \class Animator Animator.h gltfio/Animator.h
@@ -85,11 +88,20 @@ public:
     // For internal use only.
     void addInstance(FFilamentInstance* instance);
 
-    /** Add the model to be animated. */
-    void addAnimatedAsset(FilamentAsset* assetToAnimate);
+    /** Add the model to be animated. 
+     * 
+     * NOTE: by default Animator creates and owns an internal morpher of type MorphHelper.
+     * But if an external morpher is supplied here the internal one will not be created.
+    */
+    void addAnimatedAsset(FilamentAsset* assetToAnimate, Morpher* morpher);
 
     /** Remove the model to be animated. */
     void removeAnimatedAsset();
+
+    template<class T>
+    static Morpher* createMorpher(FilamentAsset* asset, FilamentInstance* instance = nullptr);
+
+    static void destroyMorpher(Morpher* morpher);
 
 private:
 
@@ -101,7 +113,8 @@ private:
     Animator(FFilamentAsset* asset, FFilamentInstance* instance);
     bool loadAnimatorImpl(FFilamentAsset* asset, FFilamentInstance* instance,
         bool validateMorphChannels = true);
-    void addAnimatedAsset(FFilamentAsset* asset, FFilamentInstance* instance);
+    void addAnimatedAsset(FFilamentAsset* asset, FFilamentInstance* instance,
+        Morpher* morpher);
     AnimatorImpl* mImpl;
 };
 

--- a/libs/gltfio/src/CPUMorpher.cpp
+++ b/libs/gltfio/src/CPUMorpher.cpp
@@ -1,0 +1,242 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "CPUMorpher.h"
+
+#include <filament/BufferObject.h>
+#include <filament/RenderableManager.h>
+#include <filament/VertexBuffer.h>
+
+#include "GltfHelpers.h"
+
+using namespace filament;
+using namespace filament::math;
+using namespace utils;
+
+namespace gltfio {
+
+static const auto FREE_CALLBACK = [](void* mem, size_t, void*) { free(mem); };
+
+CPUMorpher::CPUMorpher(FFilamentAsset* asset, FFilamentInstance* instance) : mAsset(asset) {
+    NodeMap& sourceNodes = asset->mNodeMap;
+    for (auto pair : sourceNodes) {
+        cgltf_node const* node = pair.first;
+        cgltf_mesh const* mesh = node->mesh;
+        if (mesh) {
+            cgltf_primitive const* prims = mesh->primitives;
+            for (cgltf_size pi = 0, count = mesh->primitives_count; pi < count; ++pi) {
+                if (mesh->primitives[pi].targets_count > 0) {
+                    addPrimitive(mesh, pi, &mMorphTable[pair.second]);
+                }
+            }
+        }
+    }
+}
+
+CPUMorpher::~CPUMorpher() {
+    auto engine = mAsset->mEngine;
+    for (auto& entry : mMorphTable) {
+        for (auto& prim : entry.second.primitives) {
+            if (prim.morphBuffer1) engine->destroy(prim.morphBuffer1);
+            if (prim.morphBuffer2) engine->destroy(prim.morphBuffer2);
+        }
+    }
+}
+
+void CPUMorpher::applyWeights(Entity entity, float const* weights, size_t count) noexcept {
+    auto& engine = *mAsset->mEngine;
+    auto renderableManager = &engine.getRenderableManager();
+    auto renderable = renderableManager->getInstance(entity);
+
+    for (auto& prim : mMorphTable[entity].primitives) {
+        if (prim.targets.size() < count) {
+            continue;
+        }
+
+        size_t size = prim.floatsCount * sizeof(float);
+        float* data = (float*) malloc(size);
+        memset(data, 0, size);
+
+        for (size_t index = 0; index < count; index ++) {
+            const float w = weights[index];
+            if (w < 0.0001f) continue;
+
+            const GltfTarget& target = prim.targets[index];
+            cgltf_size dim = cgltf_num_components(target.type); 
+
+            for (size_t i = 0; i < target.indices.size(); ++i) {
+                uint16_t index = target.indices[i];
+                for (size_t j = 0; j < dim; ++j) {
+                    data[index * dim + j] += w * target.values[i * dim + j];
+                }
+            }
+        }
+        
+        VertexBuffer* vb = prim.vertexBuffer;
+        if (!prim.morphBuffer1) {
+            prim.morphBuffer1 = BufferObject::Builder().size(size).build(engine);
+        }
+        if (!prim.morphBuffer2 && count >= 2) {
+            // This is for dealing with a bug in filament shaders where empty normals are not
+            // handled correctly.
+            //
+            // filament shaders deal with tangent frame quaternions instead of normal vectors.
+            // But in case of missing inputs, we get a invalid quaternion (0, 0, 0, 0) instead of
+            // a identity quaterion. This leads to the normals being morphed even no inputs are
+            // given.
+            // 
+            // To fix this, we put a empty morph target at slot 2 and give it a weight of -1.
+            // This won't affect the vertex positions but will cancel out the normal values.
+            //
+            // Note that for this to work, at least two morph targets are required.
+            float* data2 = (float*) malloc(size);
+            memset(data2, 0, size);
+            VertexBuffer::BufferDescriptor bd2(data2, size, FREE_CALLBACK);
+            prim.morphBuffer2 = BufferObject::Builder().size(size).build(engine);
+            prim.morphBuffer2->setBuffer(engine, std::move(bd2));
+            vb->setBufferObjectAt(engine, prim.baseSlot+1, prim.morphBuffer2);
+        }
+        VertexBuffer::BufferDescriptor bd(data, size, FREE_CALLBACK);
+        prim.morphBuffer1->setBuffer(engine, std::move(bd));
+        vb->setBufferObjectAt(engine, prim.baseSlot, prim.morphBuffer1);
+    }
+    renderableManager->setMorphWeights(renderable, {1, -1, 0, 0});
+}
+
+void CPUMorpher::addPrimitive(cgltf_mesh const* mesh, int primitiveIndex, TableEntry* entry) {
+    auto& engine = *mAsset->mEngine;
+    const cgltf_primitive& cgltf_prim = mesh->primitives[primitiveIndex];
+
+    int posIndex = findPositionAttribute(cgltf_prim);
+    if (posIndex < 0) return;
+
+    VertexBuffer* vertexBuffer = mAsset->mMeshCache.at(mesh)[primitiveIndex].vertices;
+    int slot = determineBaseSlot(cgltf_prim);
+    entry->primitives.push_back({ vertexBuffer, slot });
+
+    auto& primitive = entry->primitives.back();
+
+    cgltf_attribute& positionAttribute = cgltf_prim.attributes[posIndex];
+    size_t dim = cgltf_num_components(positionAttribute.data->type);
+    primitive.floatsCount = positionAttribute.data->count * dim;
+
+    std::vector<GltfTarget>& targets = primitive.targets;
+
+    for (int targetIndex = 0; targetIndex < cgltf_prim.targets_count; targetIndex++) {
+        const cgltf_morph_target& morphTarget = cgltf_prim.targets[targetIndex];
+        for (cgltf_size aindex = 0; aindex < morphTarget.attributes_count; aindex++) {
+            const cgltf_attribute& attribute = morphTarget.attributes[aindex];
+            const cgltf_accessor* accessor = attribute.data;
+            const cgltf_attribute_type atype = attribute.type;
+
+            // only works for morphing of positions for now
+            if (atype == cgltf_attribute_type_position) {
+                targets.push_back({targetIndex, atype, accessor->type});
+
+                // expect the morph target to use a sparse accessor
+                if (accessor->is_sparse) {
+                    const cgltf_accessor_sparse& sparse = accessor->sparse;
+                    
+                    const uint8_t* index_data = cgltf_buffer_view_data(sparse.indices_buffer_view);
+		            const uint8_t* reader_head = cgltf_buffer_view_data(sparse.values_buffer_view);
+
+                    index_data += sparse.indices_byte_offset;
+                    reader_head += sparse.values_byte_offset;
+
+                    cgltf_size index_stride = cgltf_component_size(sparse.indices_component_type);
+
+                    cgltf_size floats_per_element = cgltf_num_components(accessor->type);
+                    targets.back().indices.resize(sparse.count);
+                    targets.back().values.resize(sparse.count * floats_per_element);
+
+                    for (cgltf_size reader_index = 0; reader_index < sparse.count; reader_index++) {
+                        targets.back().indices[reader_index] = cgltf_component_read_index(index_data, 
+                            sparse.indices_component_type);
+                        cgltf_element_read_float(reader_head, accessor->type, accessor->component_type, 
+                            accessor->normalized, 
+                            targets.back().values.data() + reader_index * floats_per_element, 
+                            floats_per_element);
+                        index_data += index_stride;
+                        reader_head += accessor->stride;
+                    } 
+                }
+            }
+        }
+    }
+}
+
+// trying to find the slot for the vertex position
+int CPUMorpher::determineBaseSlot(const cgltf_primitive& prim) const {
+    int slot = 0;
+    bool hasNormals = false;
+    for (cgltf_size aindex = 0; aindex < prim.attributes_count; aindex++) {
+        const cgltf_attribute& attribute = prim.attributes[aindex];
+        const int index = attribute.index;
+        const cgltf_attribute_type atype = attribute.type;
+        const cgltf_accessor* accessor = attribute.data;
+        if (atype == cgltf_attribute_type_tangent) {
+            continue;
+        }
+        if (atype == cgltf_attribute_type_normal) {
+            slot++;
+            hasNormals = true;
+            continue;
+        }
+
+        // Filament supports two set of texcoords. But whether or not UV1 is actually used also
+        // depends on the material.
+        // Note this is a very specific fix that might not work in all cases.
+        if (atype == cgltf_attribute_type_texcoord && index > 0) {
+            bool hasUV1 = false;
+            cgltf_material* mat = prim.material;
+            if (mat->has_pbr_metallic_roughness) {
+                if (mat->pbr_metallic_roughness.base_color_texture.texcoord != 0) {
+                    hasUV1 = true;
+                }
+                if (mat->pbr_metallic_roughness.metallic_roughness_texture.texcoord != 0) {
+                    hasUV1 = true;
+                }
+            }
+            if (mat->normal_texture.texcoord != 0) hasUV1 = true;
+            if (mat->emissive_texture.texcoord != 0) hasUV1 = true;
+            if (mat->occlusion_texture.texcoord != 0) hasUV1 = true;
+
+            if (hasUV1) slot++;
+            continue;
+        }
+        
+        slot++;
+    }
+
+    // If the model has lighting but not normals, then a slot is used for generated flat normals.
+    if (prim.material && !prim.material->unlit && !hasNormals) {
+        slot++;
+    }
+
+    return slot;
+};
+
+int CPUMorpher::findPositionAttribute(const cgltf_primitive& prim) const {
+    for (cgltf_size aindex = 0; aindex < prim.attributes_count; aindex++) {
+        if (prim.attributes[aindex].type == cgltf_attribute_type_position) {
+            return aindex;
+        }
+    }
+
+    return -1;
+};
+
+} // namespace gltfio

--- a/libs/gltfio/src/CPUMorpher.h
+++ b/libs/gltfio/src/CPUMorpher.h
@@ -14,6 +14,9 @@
  * limitations under the License.
  */
 
+#ifndef GLTFIO_CPUMORPHER_H
+#define GLTFIO_CPUMORPHER_H
+
 #include "Morpher.h"
 
 #include "FFilamentAsset.h"
@@ -28,53 +31,58 @@
 struct cgltf_node;
 struct cgltf_mesh;
 struct cgltf_primitive;
+struct cgltf_attribute;
 
 namespace gltfio {
 
 /**
- * Internal class that partitions lists of morph weights and maintains a cache of BufferObject
- * instances. This allows gltfio to support up to 255 morph targets.
+ * Helper for supporting more than 4 active morph targets.
  *
- * Each partition is associated with an unordered set of 4 (or fewer) morph target indices, which
- * we call the "primary indices" for that time slice.
- *
- * Animator has ownership over a single instance of MorphHelper, thus it is 1:1 with FilamentAsset.
+ * All morph values are calculated on CPU and collected into a single target, which will be
+ * uploaded with weight of 1. This is effectively doing the morphing on CPU.
+ * 
+ * Obviously this is slower than the stock morpher as it needs to upload buffer every frame.
+ * So beware of the performance penalty.
  */
-class MorphHelper : public Morpher {
+class CPUMorpher : public Morpher {
 public:
     using Entity = utils::Entity;
-    MorphHelper(FFilamentAsset* asset, FFilamentInstance* inst);
-    ~MorphHelper();
+    CPUMorpher(FFilamentAsset* asset, FFilamentInstance* instance);
+    ~CPUMorpher();
 
-    /**
-     * Picks the 4 most influential weights and applies them to the target entity.
-     */
     void applyWeights(Entity targetEntity, float const* weights, size_t count) noexcept;
 
 private:
     struct GltfTarget {
-        filament::BufferObject* bufferObject;
         int morphTargetIndex;
-        cgltf_attribute_type type;
+        cgltf_attribute_type attribute_type;
+        cgltf_type type;
+        std::vector<uint16_t> indices;
+        std::vector<float> values;
     };
 
     struct GltfPrimitive {
         filament::VertexBuffer* vertexBuffer;
-        uint8_t positions[4];
-        uint8_t tangents[4];
-        std::vector<GltfTarget> targets; // TODO: flatten this?
+        int baseSlot;
+        size_t floatsCount;
+        filament::BufferObject* morphBuffer1 = nullptr;
+        filament::BufferObject* morphBuffer2 = nullptr;
+        std::vector<GltfTarget> targets;
     };
 
     struct TableEntry {
-        std::vector<GltfPrimitive> primitives; // TODO: flatten this?
+        std::vector<GltfPrimitive> primitives;
     };
 
     void addPrimitive(cgltf_mesh const* mesh, int primitiveIndex, TableEntry* entry);
+    int determineBaseSlot(const cgltf_primitive& prim) const;
+    int findPositionAttribute(const cgltf_primitive& prim) const;
 
     std::vector<float> mPartiallySortedWeights;
     tsl::robin_map<Entity, TableEntry> mMorphTable;
     const FFilamentAsset* mAsset;
-    const FFilamentInstance* mInstance;
 };
 
 } // namespace gltfio
+
+#endif // GLTFIO_CPUMORPHER_H

--- a/libs/gltfio/src/GltfHelpers.h
+++ b/libs/gltfio/src/GltfHelpers.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2019 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLTFIO_GLTFHELPERS_H
+#define GLTFIO_GLTFHELPERS_H
+
+#include <cgltf.h>
+
+static const uint8_t* cgltf_buffer_view_data(const cgltf_buffer_view* view) {
+	if (view->data)
+		return (const uint8_t*)view->data;
+
+	if (!view->buffer->data)
+		return NULL;
+
+	const uint8_t* result = (const uint8_t*)view->buffer->data;
+	result += view->offset;
+	return result;
+}
+
+static cgltf_size cgltf_component_size(cgltf_component_type component_type) {
+	switch (component_type)
+	{
+	case cgltf_component_type_r_8:
+	case cgltf_component_type_r_8u:
+		return 1;
+	case cgltf_component_type_r_16:
+	case cgltf_component_type_r_16u:
+		return 2;
+	case cgltf_component_type_r_32u:
+	case cgltf_component_type_r_32f:
+		return 4;
+	case cgltf_component_type_invalid:
+	default:
+		return 0;
+	}
+}
+
+static cgltf_size cgltf_component_read_index(const void* in, cgltf_component_type component_type) {
+	switch (component_type)
+	{
+		case cgltf_component_type_r_16:
+			return *((const int16_t*) in);
+		case cgltf_component_type_r_16u:
+			return *((const uint16_t*) in);
+		case cgltf_component_type_r_32u:
+			return *((const uint32_t*) in);
+		case cgltf_component_type_r_32f:
+			return (cgltf_size)*((const float*) in);
+		case cgltf_component_type_r_8:
+			return *((const int8_t*) in);
+		case cgltf_component_type_r_8u:
+			return *((const uint8_t*) in);
+		default:
+			return 0;
+	}
+}
+
+static cgltf_float cgltf_component_read_float(const void* in, cgltf_component_type component_type, 
+        cgltf_bool normalized) {
+	if (component_type == cgltf_component_type_r_32f)
+	{
+		return *((const float*) in);
+	}
+
+	if (normalized)
+	{
+		switch (component_type)
+		{
+			// note: glTF spec doesn't currently define normalized conversions for 32-bit integers
+			case cgltf_component_type_r_16:
+				return *((const int16_t*) in) / (cgltf_float)32767;
+			case cgltf_component_type_r_16u:
+				return *((const uint16_t*) in) / (cgltf_float)65535;
+			case cgltf_component_type_r_8:
+				return *((const int8_t*) in) / (cgltf_float)127;
+			case cgltf_component_type_r_8u:
+				return *((const uint8_t*) in) / (cgltf_float)255;
+			default:
+				return 0;
+		}
+	}
+
+	return (cgltf_float)cgltf_component_read_index(in, component_type);
+}
+
+static cgltf_bool cgltf_element_read_float(const uint8_t* element, cgltf_type type, 
+        cgltf_component_type component_type, cgltf_bool normalized, cgltf_float* out, 
+        cgltf_size element_size) {
+	cgltf_size num_components = cgltf_num_components(type);
+
+	if (element_size < num_components) {
+		return 0;
+	}
+
+	// There are three special cases for component extraction, see #data-alignment in the 2.0 spec.
+
+	cgltf_size component_size = cgltf_component_size(component_type);
+
+	for (cgltf_size i = 0; i < num_components; ++i)
+	{
+		out[i] = cgltf_component_read_float(element + component_size * i, component_type, normalized);
+	}
+	return 1;
+}
+
+#endif // GLTFIO_GLTFHELPERS_H

--- a/libs/gltfio/src/Morpher.h
+++ b/libs/gltfio/src/Morpher.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2021 The Android Open Source Project
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef GLTFIO_MORPHER_H
+#define GLTFIO_MORPHER_H
+
+#include <utils/Entity.h>
+
+namespace gltfio {
+
+class FilamentAsset;
+class FilamentInstance;
+
+class Morpher {
+public:
+    using Entity = utils::Entity;
+    virtual ~Morpher() = default;
+    virtual void applyWeights(Entity targetEntity, float const* weights, size_t count) noexcept = 0;
+};
+
+} // namespace gltfio
+
+#endif // GLTFIO_MORPHER_H


### PR DESCRIPTION
- add cpu morpher which supports more than 4 active targets
- add common interface for morphers
- change Animator to allow swapping out the stock MorphHelper for the
new CPUMorpher
- change Animator to allow morphers to be managed externally